### PR TITLE
fix: remove IAM Identity Center requirement from salesforce chat embe…

### DIFF
--- a/docs/use-cases/salesforce-chat-embed/README.md
+++ b/docs/use-cases/salesforce-chat-embed/README.md
@@ -13,7 +13,7 @@ Embed an Amazon Quick Chat Agent into Salesforce as a Lightning Web Component (L
 Salesforce User (logged in)
   → Lightning page loads LWC
   → LWC renders iframe with Quick Chat Agent embed URL
-  → User authenticates via Quick (IDC-backed)
+  → User authenticates via Quick (password or SSO)
   → Chat Agent is interactive inside Salesforce
 ```
 
@@ -21,7 +21,7 @@ Salesforce User (logged in)
 
 - AWS account with Amazon Quick Enterprise Edition
 - A Quick Chat Agent created and configured
-- IAM Identity Center with users provisioned in Quick
+- A Quick account with users provisioned (password-based or single sign-on)
 - Salesforce org with Lightning Experience enabled
 - Salesforce CLI (`sf`) installed (`brew install sf`)
 
@@ -121,9 +121,8 @@ salesforce-chat-embed/
 ## User Access
 
 Users accessing the Chat Agent in Salesforce must have:
-1. An **IAM Identity Center** account
-2. A **Quick** registered user (same email as IDC)
-3. Access to the Chat Agent's underlying topics/data in Quick
+1. A **Quick** account with a provisioned user (password-based or SSO)
+2. Access to the Chat Agent's underlying topics/data in Quick
 
 ## Production Considerations
 


### PR DESCRIPTION
…d docs

IAM Identity Center is not required for iframe embedding. Only a Quick account with users provisioned via password or SSO is needed.

## Description

Brief description of changes to the Amazon Quick Suite Knowledge Hub

## Type of Change

- [ ] Bug fix (fixes an issue in integration guides or use cases)
- [ ] New integration guide (adds setup documentation for a supported service)
- [ ] New use case (adds end-to-end solution example)
- [x] Documentation improvement (updates existing content)
- [ ] Website enhancement (navigation, styling, or functionality)

## Testing

- [ ] Documentation builds successfully (`mkdocs build`)
- [ ] All links are valid and working
- [ ] Content renders correctly locally (`mkdocs serve`)
- [ ] Integration steps tested (if applicable)
- [ ] Screenshots and images display properly

## Checklist

- [ ] My content follows the Amazon Quick Suite Knowledge Hub style guidelines
- [ ] I have performed a self-review of my content
- [ ] I have updated navigation (mkdocs.yml) if adding new content
- [ ] My changes generate no new warnings or errors
- [ ] All external links are valid and accessible
- [ ] Content is accurate and up-to-date

## Amazon Quick Suite Knowledge Hub Guidelines

- [ ] No hardcoded secrets, credentials, or sensitive data
- [ ] All service names and versions are specified
- [ ] Screenshots include proper Amazon Quick Suite branding
- [ ] Integration steps are clear and complete
- [ ] Troubleshooting section included (if applicable)

## Breaking Changes

List any breaking changes and migration instructions:

N/A

## Additional Notes

Add any additional context about this contribution to the Amazon Quick Suite Knowledge Hub.
